### PR TITLE
Make Segments immutable objects

### DIFF
--- a/richtextfx-demos/src/main/java/org/fxmisc/richtext/demo/richtext/CustomObject.java
+++ b/richtextfx-demos/src/main/java/org/fxmisc/richtext/demo/richtext/CustomObject.java
@@ -8,20 +8,16 @@ import org.fxmisc.richtext.model.Codec;
 
 import javafx.scene.Node;
 
-public abstract class CustomObject<S> {
+public interface CustomObject<S> {
 
-    S style;
+    S getStyle();
 
-    protected CustomObject() {}
+    CustomObject<S> setStyle(S style);
 
-    public CustomObject(S style) {
-        this.style = style;
-    }
+    void decode(DataInputStream is, Codec<S> styleCodec) throws IOException;
 
+    void encode(DataOutputStream os, Codec<S> styleCodec) throws IOException;
 
-    public abstract void decode(DataInputStream is, Codec<S> styleCodec) throws IOException;
+    Node createNode();
 
-    public abstract void encode(DataOutputStream os, Codec<S> styleCodec) throws IOException;
-
-    public abstract Node createNode();
 }

--- a/richtextfx-demos/src/main/java/org/fxmisc/richtext/demo/richtext/CustomObjectOps.java
+++ b/richtextfx-demos/src/main/java/org/fxmisc/richtext/demo/richtext/CustomObjectOps.java
@@ -46,7 +46,7 @@ public class CustomObjectOps<S> implements SegmentOps<CustomObject<S>, S> {
 
     @Override
     public S getStyle(CustomObject<S> seg) {
-        return seg.style;
+        return seg.getStyle();
     }
 
     @Override
@@ -70,7 +70,8 @@ public class CustomObjectOps<S> implements SegmentOps<CustomObject<S>, S> {
     }
 
     @Override
-    public void setStyle(CustomObject<S> seg, S style) {
+    public CustomObject<S> setStyle(CustomObject<S> seg, S style) {
+        return seg.setStyle(style);
     }
 
     @Override

--- a/richtextfx-demos/src/main/java/org/fxmisc/richtext/demo/richtext/StyledTextOrCustomObjectOps.java
+++ b/richtextfx-demos/src/main/java/org/fxmisc/richtext/demo/richtext/StyledTextOrCustomObjectOps.java
@@ -122,12 +122,10 @@ public class StyledTextOrCustomObjectOps { // <S> implements SegmentOps<Either<S
             }
 
             @Override
-            public void setStyle(Either<StyledText<S>, CustomObject<S>> seg, S style) {
-                if (seg.isLeft()) {
-                    lOps.setStyle(seg.getLeft(), style);
-                } else {
-                    rOps.setStyle(seg.getRight(), style);
-                }
+            public Either<StyledText<S>, CustomObject<S>> setStyle(Either<StyledText<S>, CustomObject<S>> seg, S style) {
+                return seg.isLeft()
+                        ? Either.left(lOps.setStyle(seg.getLeft(), style))
+                        : Either.right(rOps.setStyle(seg.getRight(), style));
             }
 
             @Override

--- a/richtextfx/src/main/java/org/fxmisc/richtext/model/SegmentOps.java
+++ b/richtextfx/src/main/java/org/fxmisc/richtext/model/SegmentOps.java
@@ -28,7 +28,7 @@ public interface SegmentOps<SEG, S> {
 
     public S getStyle(SEG seg);
 
-    public void setStyle(SEG seg, S style);
+    public SEG setStyle(SEG seg, S style);
 
     public String toString(SEG seg);
 

--- a/richtextfx/src/main/java/org/fxmisc/richtext/model/StyledText.java
+++ b/richtextfx/src/main/java/org/fxmisc/richtext/model/StyledText.java
@@ -12,10 +12,6 @@ public class StyledText<S>  {
     private S style;
     public S getStyle() { return style; }
 
-    public void setStyle(S style) {
-        this.style = style;
-    }
-
     StyledText() { }
 
     public StyledText(String text, S style) {

--- a/richtextfx/src/main/java/org/fxmisc/richtext/model/StyledTextOps.java
+++ b/richtextfx/src/main/java/org/fxmisc/richtext/model/StyledTextOps.java
@@ -76,8 +76,8 @@ public final class StyledTextOps<S> implements SegmentOps<StyledText<S>, S> {
     }
 
     @Override
-    public void setStyle(StyledText<S> seg, S style) {
-        seg.setStyle(style);
+    public StyledText<S> setStyle(StyledText<S> seg, S style) {
+        return new StyledText<>(seg.getText(), style);
     }
 
     @Override


### PR DESCRIPTION
- Rather than having the `style` stored in the CustomObject, this was abstracted out for other classes to implement. Since the resulting class had no real constructors, the class was turned into an interface.

Note: ReadOnlyStyledDocument's `testRestyle` test fails in this commit.
